### PR TITLE
Add support for `content_type = "mixed"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Following options can be given when calling setup({config}). Below is the defaul
 ```lua
 {
 -- max width the fortune section should take place
-max_width = 60, 
+max_width = 60,
 
 -- Controls the amout of text displayed
 -- short - One liners (default)
@@ -47,6 +47,7 @@ display_format = "short",
 -- The type of fortune to display
 -- quotes - Random techy quotes
 -- tips - Neovim productivity tips
+-- mixed - Combination of above
 content_type = "quotes"
 }
 ```

--- a/lua/fortune/init.lua
+++ b/lua/fortune/init.lua
@@ -70,7 +70,7 @@ end
 local options = {
   max_width = 60,
   display_format = "short", -- 'short', 'long', ',mixed'
-  content_type = "quotes", -- 'quotes' and 'tips'
+  content_type = "quotes", -- 'quotes', 'tips', 'mixed'
 }
 
 --- Sets up the options for the module.
@@ -87,14 +87,26 @@ end
 
 --- @return table
 M.get_fortune = function()
-  local all_list = options.content_type == "quotes" and require("fortune.quotes") or require("fortune.tips")
+  local all_list
+  if options.content_type == "mixed" then
+    local content_providers = {}
+    table.insert(content_providers, require("fortune.quotes"))
+    table.insert(content_providers, require("fortune.tips"))
+    all_list = {short = {}, long = {}}
+    for _, format in ipairs({"short", "long"}) do
+      for _, content_provider in ipairs(content_providers) do
+        for _, v in pairs(content_provider[format]) do table.insert(all_list[format], v) end
+      end
+    end
+  else
+    all_list = options.content_type == "quotes" and require("fortune.quotes") or require("fortune.tips")
+  end
   local content
   if options.display_format == "mixed" then
     content = vim.tbl_extend("force", {}, all_list["short"], all_list["long"])
   else
     content = all_list[options.display_format]
   end
-
   local fortune = random_fortune(content)
   local formatted_fortune = M.format_fortune(fortune, options.max_width)
 


### PR DESCRIPTION
There are many strategies that could achieve this, in this commit I take the approach of simply merging the two content providers. This also makes it easy to extend to new content providers.

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/rubiin/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

With this PR, we can set `content_type = "mixed"` allowing us to pul from both the "quotes" and "tips" fortunes.

### Linked Issues
N/A

### Additional context

N/A
