### PR TITLE
Allow user to provide custom quotes and tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Following options can be given when calling setup({config}). Below is the defaul
 -- max width the fortune section should take place
 max_width = 60,
 
--- Controls the amout of text displayed
+-- Controls the amount of text displayed
 -- short - One liners (default)
 -- long - Multiple lines
 -- mixed - Combination of above
@@ -49,6 +49,32 @@ display_format = "short",
 -- tips - Neovim productivity tips
 -- mixed - Combination of above
 content_type = "quotes"
+
+-- An optional object of custom quotes to replace the default ones like this:
+-- {
+--     short = {
+--         { "This is a short quote", "- Author" },
+--         { "This is another short quote", "- Author" },
+--     },
+--     long = {
+--         { "This is a long quote", "- Author" },
+--         { "This is another long quote", "- Author" },
+--     }
+-- }
+custom_quotes = {},
+
+-- An optional object of custom tips to replace the default ones like this:
+-- {
+--     short = {
+--         { "In normal mode, x will delete a single character" },
+--         { "In visual mode, x will delete a range of characters" },
+--     },
+--     long = {
+--         { "To delete from the current line to the end of the line, use d$" },
+--         { "To delete from the current line to the beginning of the line, use d^" },
+--     }
+-- }
+custom_tips = {},
 }
 ```
 

--- a/lua/fortune/init.lua
+++ b/lua/fortune/init.lua
@@ -71,6 +71,8 @@ local options = {
   max_width = 60,
   display_format = "short", -- 'short', 'long', ',mixed'
   content_type = "quotes", -- 'quotes', 'tips', 'mixed'
+  custom_quotes = {},
+  custom_tips = {},
 }
 
 --- Sets up the options for the module.
@@ -78,6 +80,8 @@ local options = {
 --- max_width (number): The maximum width for content display.
 --- display_format (string): The format for displaying content. Can be 'short'.
 --- content_type (string): The type of content to display. Can be 'quotes' or 'tips'.
+--- custom_quotes (table): A table containing custom quotes to display. If set, replaces default quotes.
+--- custom_tips (table): A table containing custom tips to display. If set, replaces default tips.
 --- @return nil
 M.setup = function(opts)
   if opts ~= nil then
@@ -88,18 +92,23 @@ end
 --- @return table
 M.get_fortune = function()
   local all_list
+  local quotes = next(options.custom_quotes) and options.custom_quotes or require("fortune.quotes")
+  local tips = next(options.custom_tips) and options.custom_tips or require("fortune.tips")
+
   if options.content_type == "mixed" then
     local content_providers = {}
-    table.insert(content_providers, require("fortune.quotes"))
-    table.insert(content_providers, require("fortune.tips"))
-    all_list = {short = {}, long = {}}
-    for _, format in ipairs({"short", "long"}) do
+    table.insert(content_providers, quotes)
+    table.insert(content_providers, tips)
+    all_list = { short = {}, long = {} }
+    for _, format in ipairs({ "short", "long" }) do
       for _, content_provider in ipairs(content_providers) do
-        for _, v in pairs(content_provider[format]) do table.insert(all_list[format], v) end
+        for _, v in pairs(content_provider[format]) do
+          table.insert(all_list[format], v)
+        end
       end
     end
   else
-    all_list = options.content_type == "quotes" and require("fortune.quotes") or require("fortune.tips")
+    all_list = options.content_type == "quotes" and quotes or tips
   end
   local content
   if options.display_format == "mixed" then


### PR DESCRIPTION
During setup, allow the user to provide a table of custom quotes and/or tips. Document this in the README with examples.

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/rubiin/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Allow users to optionally provide their own custom quotes and/or tips during setup.

Example lazy.nvim plugin config:

```lua
{
  "mikedfunk/fortune.nvim",
  opts = {
    display_format = "mixed",
    custom_quotes = {
      short = {
        { "The best way to predict the future is to invent it." },
      },
      long = {
        { "The pessimist sees difficulty in every opportunity. The optimist sees opportunity in every difficulty." },
      }
    },
  },
},
```

<img width="579" alt="image" src="https://github.com/rubiin/fortune.nvim/assets/661038/18eda32b-fab3-4ca5-82d3-0c09e531a713">


### Linked Issues

N/A

### Additional context

If you prefer, I will avoid requiring the quotes/tips until they are requested. I extracted them to local variables to define them once for use in multiple places.